### PR TITLE
[OCPTELAN-757]: Changes related to renaming groupname for the analytics operator

### DIFF
--- a/openshift/prerequisite.yaml
+++ b/openshift/prerequisite.yaml
@@ -51,7 +51,7 @@ rules:
       - view
       - delete
     apiGroups:
-      - backend.anomaly.io
+      - observability-analytics.redhat.com
     resources:
       - anomalydata
 ---
@@ -105,9 +105,9 @@ data:
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1
 metadata:
-  name: anomalydata.backend.anomaly.io
+  name: anomalydata.observability-analytics.redhat.com
 spec:
-  group: backend.anomaly.io
+  group: observability-analytics.redhat.com
   names:
     plural: anomalydata
     singular: anomalydata

--- a/src/anomaly/abstract_anomaly_detector.py
+++ b/src/anomaly/abstract_anomaly_detector.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 import daiquiri
 
-from src.common.config import DAIQUIRI_LOG_LEVEL
+from src.common.config import DAIQUIRI_LOG_LEVEL, ANOMALY_CR_CONFIG
 
 daiquiri.setup(level=DAIQUIRI_LOG_LEVEL)
 _logger = daiquiri.getLogger(__name__)
@@ -41,8 +41,8 @@ class AbstractAnomalyDetector(metaclass=ABCMeta):
 
         # Build anomaly object that will be saved to CR in cluster later point
         anomaly_obj = {
-            "apiVersion": "backend.anomaly.io/v1alpha1",
-            "kind": "AnomalyData",
+            "apiVersion": f"{ANOMALY_CR_CONFIG['group']}/{ANOMALY_CR_CONFIG['version']}",
+            "kind": ANOMALY_CR_CONFIG["kind"],
             "metadata": {
                 "label": {"app.kubernetes.io/created-by": "anomaly-engine"},
                 "name": name,

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -21,3 +21,12 @@ MIN_NO_OF_DATA_POINTS = int(os.environ.get("MIN_NO_OF_DATA_POINTS", 10))
 # Default parameter for the "min_max" query type
 MIN_VALUE = int(os.environ.get("MIN_VALUE", 100))
 MAX_VALUE = int(os.environ.get("MAX_VALUE", 1000))
+
+# Config to store anomaly data into `AnomalyData` CR
+ANOMALY_CR_CONFIG = {
+    "group": os.environ.get("ANOMALY_CR_GROUP", "observability-analytics.redhat.com"),
+    "version": os.environ.get("ANOMALY_CR_VERSION", "v1alpha1"),
+    "namespace": os.environ.get("ANOMALY_CR_NAMESPACE", "osa-anomaly-detection"),
+    "plural": os.environ.get("ANOMALY_CR_PLURAL", "anomalydata"),
+    "kind": os.environ.get("ANOMALY_CR_kIND", "AnomalyData"),
+}

--- a/src/utils/kube_utils.py
+++ b/src/utils/kube_utils.py
@@ -2,9 +2,7 @@
 import daiquiri
 from kubernetes import client
 
-from src.common.config import (
-    DAIQUIRI_LOG_LEVEL,
-)
+from src.common.config import DAIQUIRI_LOG_LEVEL, ANOMALY_CR_CONFIG
 
 daiquiri.setup(level=DAIQUIRI_LOG_LEVEL)
 _logger = daiquiri.getLogger(__name__)
@@ -14,10 +12,10 @@ def create_cr(anomaly_data):
     """Create CRD object to store anomaly data."""
     custom_api_instance = client.CustomObjectsApi()
     custom_api_instance.create_namespaced_custom_object(
-        group="backend.anomaly.io",
-        version="v1alpha1",
-        namespace="osa-anomaly-detection",
-        plural="anomalydata",
+        group=ANOMALY_CR_CONFIG["group"],
+        version=ANOMALY_CR_CONFIG["version"],
+        namespace=ANOMALY_CR_CONFIG["namespace"],
+        plural=ANOMALY_CR_CONFIG["plural"],
         body=anomaly_data,
     )
 


### PR DESCRIPTION
Signed-off-by: Raj Zalavadia [rzalavad@redhat.com](mailto:rzalavad@redhat.com)

The PR contains code changes to accommodate groupname changes for the analytics operator from `backend.anomaly.io` to `observability-analytics.redhat.com`. Anomaly data we are storing into CR so we need to change related code here. 

Related story: https://issues.redhat.com/browse/OCPTELAN-757

cc: @dvandra @Anxhela21 