### PR TITLE
fix: making name with lowercase

### DIFF
--- a/src/anomaly/abstract_anomaly_detector.py
+++ b/src/anomaly/abstract_anomaly_detector.py
@@ -37,7 +37,7 @@ class AbstractAnomalyDetector(metaclass=ABCMeta):
                 name = name + "-" + value
 
         # convert name based on kubernetes data standards.
-        name = name.replace(" ", "-").replace("_", "-")
+        name = name.replace(" ", "-").replace("_", "-").lower()
 
         # Build anomaly object that will be saved to CR in cluster later point
         anomaly_obj = {

--- a/tests/src/anomaly/test_percentage_change_anomaly.py
+++ b/tests/src/anomaly/test_percentage_change_anomaly.py
@@ -38,12 +38,15 @@ class PercentageChangeAnomalyTestCase(TestCase):
 
         # create anomaly detection class object and call detect_anomaly method
         anomaly_detection_obj = PercentageChangeAnomaly(
-            data=data, metric_info={"resource": "configmaps"}, config=self._config
+            data=data, metric_info={"resource": "Configmaps"}, config=self._config
         )
         anomaly = anomaly_detection_obj.detect_anomaly()
 
         # assert results
         self.assertIsNotNone(anomaly)
+
+        self.assertTrue("metadata" in anomaly)
+        self.assertTrue(anomaly["metadata"]["name"].endswith("-etcd-object-configmaps"))
 
         self.assertTrue("spec" in anomaly)
         self.assertEqual(anomaly["spec"]["method"], self._config["method"])


### PR DESCRIPTION
As with few scenario code was not working due to group name having capital like `Failed`, so converting it to lower case while creating AnomalyData. 